### PR TITLE
Work in Progress: Update requirements.txt DO NOT MERGE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ retrying==1.3.3
 Send2Trash==1.5.0
 Shapely==1.7.1
 six==1.15.0
-terminado==0.9.1
+terminado==0.8.3
 testpath==0.4.4
 tornado==6.0.4
 traitlets==5.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,6 @@ parso==0.7.1
 pexpect==4.8.0
 pickleshare==0.7.5
 Pillow==8.0.1
-pkg-resources==0.0.0
 prometheus-client==0.8.0
 prompt-toolkit==3.0.8
 ptyprocess==0.6.0


### PR DESCRIPTION
I wanted to run your notebooks in Binder but kept getting an error because of a failed package install from your requirements.txt.  The package name is pkg-resources==0.0.0 (line 55).  It isn't a real package, It is an artifact of "pip freeze".

According to https://github.com/pypa/pip/issues/4022, this is a bug resulting from Ubuntu providing incorrect metadata to pip. There does not seem to be a good reason for this behavior. A bug was filed with Ubuntu. https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1635463

It should be safe to remove that line from your requirements.txt.